### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: Moodle Plugin CI
 
-on:
-  push:
-  pull_request:
-  schedule:
-    - cron: "33 2 * * 1" # weekly, on Monday morning
+on: [push, pull_request]
 
 jobs:
   test:
@@ -12,7 +8,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10
+        image: mariadb:11
         env:
           MYSQL_USER: "root"
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -25,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.1", "8.2"]
-        moodle-branch: ["MOODLE_403_STABLE"]
+        php: ["8.2", "8.3"]
+        moodle-branch: ["MOODLE_404_STABLE"]
         database: [mariadb]
 
     steps:


### PR DESCRIPTION
Update the test environments to match we are currently using in production, e.g. PHP 8.3, MariaDB 11.

Also, remove scheduled runs that get disabled constantly by Github because of inactivities.